### PR TITLE
Fixing issue #30 (Python 3 compatibility)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy
 sklearn
 theano
 lasagne
+future

--- a/src/SIF_embedding.py
+++ b/src/SIF_embedding.py
@@ -1,6 +1,8 @@
 import numpy as np
 from sklearn.decomposition import TruncatedSVD
 
+# Python3 compatibility
+from past.builtins import xrange
 
 def get_weighted_average(We, x, w):
     """


### PR DESCRIPTION
Allowing for backwards compatibility of xrange() so that Python 2 and 3 can both function for now.  This implies that 'future' needs to be installed.