### PR TITLE
Preventing Glove embeddings from being re-downloaded each time demo.sh is run

### DIFF
--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -3,7 +3,7 @@ WORDFILE=$DATADIR/glove.840B.300d.txt
 
 # download word vector
 if [ ! -e $WORDFILE ]; then
-wget http://nlp.stanford.edu/data/glove.840B.300d.zip
+wget --no-clobber http://nlp.stanford.edu/data/glove.840B.300d.zip
 unzip glove.840B.300d.zip -d $DATADIR
 rm glove.840B.300d.zip
 fi


### PR DESCRIPTION
Preventing Glove embeddings from being re-downloaded each time the demo script is run.